### PR TITLE
Add hash-splat to last arg in File#read to clear deprecation warning

### DIFF
--- a/lib/jekyll/haml/markup/include.rb
+++ b/lib/jekyll/haml/markup/include.rb
@@ -19,7 +19,7 @@ module Jekyll
       end
 
       def read_file_with_context(file, context)
-        File.read file, file_read_opts(context)
+        File.read file, **file_read_opts(context)
       end
 
       def split_frontmatter_and_template(file_content)


### PR DESCRIPTION
[Ruby 2.7 changed the spec of keyword arguments](https://github.com/ruby/ruby/blob/ruby_2_7/NEWS#label-The+spec+of+keyword+arguments+is+changed+towards+3.0), deprecating automatic conversion of hashes to keyword arguments.

Before this change a deprecation warning is shown.

jekyll-haml-markup-0.1.5/lib/jekyll/haml/markup/include.rb:22: warning: Using the last argument as keyword parameters is deprecated